### PR TITLE
Update footer link

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -57,7 +57,7 @@ module Danbooru
     end
 
     def source_code_url
-      "https://github.com/r888888888/danbooru"
+      "https://github.com/Iratu/atfbooru"
     end
 
     def commit_url(hash)


### PR DESCRIPTION
Current that link indicates the original danbooru. It's confusing to report bugs.